### PR TITLE
erased userId

### DIFF
--- a/src/components/forms/ProjectForm.js
+++ b/src/components/forms/ProjectForm.js
@@ -10,7 +10,6 @@ import { createProject } from '@/api/projectData';
 import { useAuth } from '@/utils/context/authContext';
 
 const initialState = {
-  userId: '',
   projectName: '',
   projectDescription: '',
   location: '',
@@ -110,7 +109,6 @@ function ProjectForm({ obj = initialState }) {
 
 ProjectForm.propTypes = {
   obj: PropTypes.shape({
-    userId: PropTypes.string,
     projectName: PropTypes.string,
     projectDescription: PropTypes.string,
     location: PropTypes.string,


### PR DESCRIPTION
API is expecting a JSON object where userId is an integer, but the incoming request is passing userId as something else—most likely a string (e.g., "123" instead of 123).